### PR TITLE
Enhance CreatePost with image/video upload UX improvements

### DIFF
--- a/src/component/social-feed/CreatePost.tsx
+++ b/src/component/social-feed/CreatePost.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from "react";
-import { useAppDispatch, useAppSelector } from "../../redux/hook"; // ✅ Use typed hooks
+import { useState, useRef } from "react"; 
+import { useAppDispatch, useAppSelector } from "../../redux/hook";
 import { createPost } from "../../redux/features/social_posts/postThunk";
-import { getUserByIdThunk } from "../../redux/features/auth/authThunk";
 import "./CreatePost.css";
 
 const CreatePost = () => {
@@ -12,15 +11,15 @@ const CreatePost = () => {
   const [content, setContent] = useState("");
   const [imageFile, setImageFile] = useState<File | null>(null);
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const storedUserId = localStorage.getItem("userId");
-  // const userId = storedUserId ? JSON.parse(storedUserId) : null;
 
   const handleSubmit = () => {
-    if (!content) {
-      alert("Please enter some content.");
+    if (!content && !imageFile) {
+      alert("Please enter content or select an image.");
       return;
     }
-
     if (!storedUserId) {
       alert("User not logged in.");
       return;
@@ -28,7 +27,7 @@ const CreatePost = () => {
 
     const formData = new FormData();
     formData.append("content", content);
-    formData.append("userId", storedUserId); // Must be a plain string, not null
+    formData.append("userId", storedUserId);
     if (imageFile) {
       formData.append("imageFile", imageFile);
     }
@@ -36,6 +35,13 @@ const CreatePost = () => {
     dispatch(createPost(formData));
     setContent("");
     setImageFile(null);
+    if (fileInputRef.current) {
+        fileInputRef.current.value = ""; 
+    }
+  };
+
+  const handleImageIconClick = () => {
+    fileInputRef.current?.click();
   };
 
   return (
@@ -55,16 +61,23 @@ const CreatePost = () => {
 
       <input
         type="file"
-        accept="image/*"
+        accept="image/*,video/*" 
         onChange={(e) => {
-          if (e.target.files) {
+          if (e.target.files && e.target.files[0]) {
             setImageFile(e.target.files[0]);
           }
         }}
+        ref={fileInputRef}
+        style={{ display: "none" }} 
       />
+      
+
+      {imageFile && <div className="file-name-display">Selected: {imageFile.name}</div>}
 
       <div className="create-post-actions">
-        <button className="action-btn">📷 Picture/Video</button>
+        <button className="action-btn" onClick={handleImageIconClick}>
+          📷 Picture/Video
+        </button>
         <button className="action-btn">👥 Tag a friend</button>
         <button className="post-btn" onClick={handleSubmit} disabled={loading}>
           {loading ? "Posting..." : "Post"}


### PR DESCRIPTION
Refactored CreatePost to use useRef for file input, allowing programmatic file selection and clearing after post submission. Updated file input to accept both images and videos, display selected file name, and improved validation to require either content or a file. Removed unused imports and streamlined the submit logic.